### PR TITLE
fix error: cannot bind non-const lvalue reference 

### DIFF
--- a/cpp11/impl.h
+++ b/cpp11/impl.h
@@ -74,8 +74,9 @@ struct MockerBase<R(P ...)> {
 
     ::testing::MockSpec<R(P...)>& gmock_CppFreeMockStubFunction(const ::testing::Matcher<P>&... p) {
         gmocker.RegisterOwner(this);
-        return gmocker.With(p ...);
-    }
+        static auto r = gmocker.With(p ...);
+        return r;
+     }
 
     virtual void RestoreToReal() = 0;
 


### PR DESCRIPTION
CppFreeMock/cpp11/impl.h:77:34: error: cannot bind non-const lvalue reference of type ‘testing::internal::MockSpec<int(std::__cxx11::basic_string, int)>&’ to an rvalue of type .....